### PR TITLE
Allow manual triggering of workflows

### DIFF
--- a/.github/workflows/conda-publish.yml
+++ b/.github/workflows/conda-publish.yml
@@ -6,6 +6,9 @@
 name: publish_conda
 
 on:
+  # Manually trigger workflow
+  workflow_dispatch
+  # Trigger with new release
   release:
     types: [published]
 

--- a/.github/workflows/mkdocs-publish-ghpages.yml
+++ b/.github/workflows/mkdocs-publish-ghpages.yml
@@ -1,5 +1,9 @@
 name: "MkDocs Publish Docs on GitHub Pages CI"
 on:
+  # Manually trigger workflow
+  workflow_dispatch
+  # Trigger when a push happens 
+  # to select branches.
   push:
     branches:
       - master


### PR DESCRIPTION
The following workflows were adapted to allow manual triggering.

- [x] `mkdocs-publish-ghpages.yml`: for creating docs with mkdocs
- [x] `conda-publish.yml`: for publishing on anaconda

---

### Resources

- https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/
- https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
- https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow